### PR TITLE
fix(images): allowlist app.notion.com for Notion page covers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -81,6 +81,11 @@ module.exports = withBundleAnalyzer({
             },
             {
                 protocol: 'https',
+                hostname: 'app.notion.com',
+                pathname: '/images/page-cover/**',
+            },
+            {
+                protocol: 'https',
                 hostname: 'images.unsplash.com',
                 pathname: '/**',
             },


### PR DESCRIPTION
## Problem

Blog cover images return **400 Bad Request** from the Next.js image optimizer in production:

```
GET https://hultman.dev/_next/image?url=https%3A%2F%2Fapp.notion.com%2Fimages%2Fpage-cover%2Fmet_bruegel_1565.jpg&w=1080&q=75  400
```

Every failing URL is a Notion built-in cover-gallery image. Notion migrated the host for those covers from `www.notion.so` → **`app.notion.com`**. That host isn't in `next.config` `images.remotePatterns`, so the optimizer rejects each request — breaking covers across the whole blog listing, not just the newly added post.

## Fix

Add an `app.notion.com` remote pattern, scoped to `/images/page-cover/**`, alongside the existing `www.notion.so` entry. The old entry is kept in case older posts still reference it.

## Test plan

- [ ] After deploy, load https://hultman.dev/blog and confirm cover images render (no 400s in the network tab)
- [ ] Verify an individual post page (`/blog/[id]`) cover renders
- [ ] Confirm existing `www.notion.so` / S3 covers still load

> Note: `next.config.ts` changes only take effect on a rebuild — this needs a deploy to fix prod.