### PR TITLE
fix(blog): show real reading time on blog listing cards

### DIFF
--- a/src/components/Blog/FeaturedPost.tsx
+++ b/src/components/Blog/FeaturedPost.tsx
@@ -19,11 +19,6 @@ interface FeaturedPostProps {
     post: BlogPost;
 }
 
-function readTime(description: string): string {
-    const words = description?.split(/\s+/).length ?? 0;
-    return `${Math.max(1, Math.ceil(words / 200))} min read`;
-}
-
 export default function FeaturedPost({ post }: FeaturedPostProps) {
     const bg = useColorModeValue('white', 'gray.800');
     const border = useColorModeValue('gray.200', 'gray.700');
@@ -96,12 +91,7 @@ export default function FeaturedPost({ post }: FeaturedPostProps) {
                         </Badge>
                     </HStack>
 
-                    <Heading
-                        as="h2"
-                        size="lg"
-                        mb={3}
-                        lineHeight={1.3}
-                    >
+                    <Heading as="h2" size="lg" mb={3} lineHeight={1.3}>
                         <LinkOverlay
                             as={NextLink}
                             href={`/blog/${post.id}`}
@@ -149,8 +139,8 @@ export default function FeaturedPost({ post }: FeaturedPostProps) {
                                   }
                               )
                             : 'Unpublished'}
-                        {post.description &&
-                            ` · ${readTime(post.description)}`}
+                        {post.readingTime != null &&
+                            ` · ${post.readingTime} min read`}
                     </Text>
                 </Flex>
             </Flex>

--- a/src/components/Blog/PostBox.tsx
+++ b/src/components/Blog/PostBox.tsx
@@ -18,11 +18,6 @@ interface PostBoxProps {
     post: BlogPost;
 }
 
-function readTime(description: string): string {
-    const words = description?.split(/\s+/).length ?? 0;
-    return `${Math.max(1, Math.ceil(words / 200))} min read`;
-}
-
 export default function PostBox({ post }: PostBoxProps) {
     const bg = useColorModeValue('white', 'gray.800');
     const border = useColorModeValue('gray.200', 'gray.700');
@@ -125,7 +120,8 @@ export default function PostBox({ post }: PostBoxProps) {
                               }
                           )
                         : 'Unpublished'}
-                    {post.description && ` · ${readTime(post.description)}`}
+                    {post.readingTime != null &&
+                        ` · ${post.readingTime} min read`}
                 </Text>
             </Flex>
         </LinkBox>

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -11,7 +11,7 @@ import {
 import { motion } from 'framer-motion';
 
 import { NextSeo } from 'next-seo';
-import { fetchNotions } from '../../services/notion';
+import { fetchBlogPostsWithReadingTime } from '../../services/notion';
 import { BlogPost as BlogPostType } from '../../types/notion';
 import PostBox from '../../components/Blog/PostBox';
 import FeaturedPost from '../../components/Blog/FeaturedPost';
@@ -121,7 +121,7 @@ function BlogPage({ posts }: Props) {
 
 export async function getStaticProps() {
     try {
-        const posts = await fetchNotions('blog', {
+        const posts = await fetchBlogPostsWithReadingTime({
             page_size: 100,
             sorts: [{ property: 'Published', direction: 'descending' }],
         });

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -21,6 +21,7 @@ import {
     pageIsPageObjectResponse,
     isBlockObjectResponse,
 } from '../utils/notion';
+import { estimateReadingTime } from '../utils/readingTime';
 
 const notion = new Client({ auth: serverConfig.NOTION_API_KEY });
 
@@ -136,6 +137,55 @@ export async function fetchNotions<T extends DatabaseName>(
         console.error('Error fetching notions:', error);
         return [];
     }
+}
+
+/**
+ * Estimate a single blog post's reading time by fetching its top-level
+ * blocks. Falls back to 1 minute if the block fetch fails so the listing
+ * never breaks on a transient Notion error.
+ */
+async function fetchBlogPostReadingTime(id: string): Promise<number> {
+    try {
+        const blockChildrenResponse = await notion.blocks.children.list({
+            block_id: id,
+        });
+        const blocks = blockChildrenResponse.results.filter(
+            isBlockObjectResponse
+        );
+        return estimateReadingTime(blocks);
+    } catch (error) {
+        console.error('Error fetching reading time for', id, error);
+        return 1;
+    }
+}
+
+/**
+ * Fetch blog posts and enrich each with a real `readingTime` derived from
+ * its content. The plain database query does not return block content, so
+ * the listing cannot compute reading time without this extra lookup.
+ *
+ * Block fetches run in small batches to stay within Notion's rate limit.
+ */
+export async function fetchBlogPostsWithReadingTime(
+    options: NotionFetchOptions = {}
+): Promise<BlogPost[]> {
+    const posts = await fetchNotions('blog', options);
+
+    const BATCH_SIZE = 5;
+    const enriched: BlogPost[] = [];
+
+    for (let i = 0; i < posts.length; i += BATCH_SIZE) {
+        const batch = posts.slice(i, i + BATCH_SIZE);
+        const batchResults = await Promise.all(
+            batch.map(async (post) => ({
+                ...post,
+                readingTime: await fetchBlogPostReadingTime(post.id),
+            }))
+        );
+        enriched.push(...batchResults);
+    }
+
+    return enriched;
 }
 
 export async function fetchNotion<T extends DatabaseName>(db: T, id: string) {

--- a/src/types/notion.ts
+++ b/src/types/notion.ts
@@ -29,6 +29,9 @@ export type BlogPost = {
     url: string;
     created_time: string;
     last_edited_time: string;
+    // Estimated reading time in minutes, computed from the post's blocks.
+    // Optional because the database query alone does not include block content.
+    readingTime?: number;
 };
 
 export type Bookmark = {


### PR DESCRIPTION
## Problem

Every card on `/blog` shows **"1 min read"** regardless of post length.

The listing cards (`PostBox`, `FeaturedPost`) computed reading time from `post.description` — a short AI-generated blurb — instead of the article body:

```ts
function readTime(description: string): string {
    const words = description?.split(/\s+/).length ?? 0;
    return `${Math.max(1, Math.ceil(words / 200))} min read`;
}
```

A ~30-word blurb always rounds to 1 minute. The detail page (`blog/[id].tsx`) already does it correctly, computing from the full post blocks via `estimateReadingTime()` — so the two views disagreed.

## Fix

Compute a real reading time from each post's content at fetch time and thread it through:

- Add optional `readingTime` to the `BlogPost` type.
- Add `fetchBlogPostsWithReadingTime()` in the Notion service. It fetches each post's blocks (in batches of 5 to respect Notion's rate limit) and runs the **same** `estimateReadingTime()` the detail page uses, so the listing and detail figures stay consistent. Falls back to 1 min on a transient block-fetch error.
- Blog listing `getStaticProps` uses the new function; cards render `post.readingTime`.
- Removes the duplicated `description`-based `readTime()` helper from both card components.

This runs in `getStaticProps` (ISR, 12h revalidate), so the extra Notion lookups happen at build/revalidation, not per request.

## Test plan

- [ ] After deploy, load `/blog` and confirm cards show varied, accurate read times (not a uniform "1 min read")
- [ ] Confirm the featured (latest) post card shows an accurate time
- [ ] Confirm the figure on a card matches the detail page's "X min read" for the same post