### PR TITLE
fix(seo): normalize base URL to prevent double slash in canonical/og/JSON-LD

### DIFF
--- a/src/next-seo.config.ts
+++ b/src/next-seo.config.ts
@@ -1,11 +1,7 @@
 import type { NextSeoProps } from 'next-seo';
+import { getBaseUrl } from './utils/baseUrl';
 
-const baseUrl =
-    typeof window !== 'undefined'
-        ? window.location.origin
-        : process.env.SITE_URL ||
-          process.env.NEXT_PUBLIC_APP_BASE_URL ||
-          'https://hultman.dev';
+const baseUrl = getBaseUrl();
 
 const config: NextSeoProps = {
     titleTemplate: '%s | Adam Hultman',

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -26,6 +26,7 @@ import BlogPostingJsonLd from '../../components/BlogPostingJsonLd';
 import { fetchNotion, fetchNotions } from '../../services/notion';
 import { NotionPageWithBlocks } from '../../types/notion';
 import { estimateReadingTime } from '../../utils/readingTime';
+import { getBaseUrl } from '../../utils/baseUrl';
 
 const roboto = Roboto({
     subsets: ['latin'],
@@ -189,13 +190,7 @@ export async function getStaticProps({
 }: GetStaticPropsContext<{ id: string }>) {
     const { id } = params!;
 
-    const baseUrl =
-        process.env.SITE_URL ||
-        process.env.NEXT_PUBLIC_APP_BASE_URL ||
-        (process.env.VERCEL_PROJECT_PRODUCTION_URL
-            ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-            : null) ||
-        'https://hultman.dev';
+    const baseUrl = getBaseUrl();
 
     try {
         const post = await fetchNotion('blog', id);

--- a/src/pages/feed.xml.tsx
+++ b/src/pages/feed.xml.tsx
@@ -1,11 +1,9 @@
 import { GetServerSideProps } from 'next';
 import { fetchNotions } from '../services/notion';
 import type { BlogPost } from '../types/notion';
+import { getBaseUrl } from '../utils/baseUrl';
 
-const SITE_URL =
-    process.env.SITE_URL ||
-    process.env.NEXT_PUBLIC_APP_BASE_URL ||
-    'https://hultman.dev';
+const SITE_URL = getBaseUrl();
 
 function escapeXml(str: string): string {
     return str

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -1,11 +1,9 @@
 import { GetServerSideProps } from 'next';
 import { fetchNotions } from '../services/notion';
 import type { BlogPost } from '../types/notion';
+import { getBaseUrl } from '../utils/baseUrl';
 
-const SITE_URL =
-    process.env.SITE_URL ||
-    process.env.NEXT_PUBLIC_APP_BASE_URL ||
-    'https://hultman.dev';
+const SITE_URL = getBaseUrl();
 
 function Sitemap() {
     // getServerSideProps will handle the response

--- a/src/utils/baseUrl.ts
+++ b/src/utils/baseUrl.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolve the site's base origin (scheme + host) with any trailing slashes
+ * removed, so callers can safely append a leading-slash path without
+ * producing a double slash:
+ *
+ *   `${getBaseUrl()}/blog/${id}` -> "https://hultman.dev/blog/<id>"
+ *
+ * A trailing slash on the SITE_URL / NEXT_PUBLIC_APP_BASE_URL env var would
+ * otherwise leak into canonical, og:url, JSON-LD, sitemap, and RSS URLs.
+ *
+ * On the client the current origin is preferred; on the server the value is
+ * resolved from environment configuration, falling back to the production
+ * domain.
+ */
+export function getBaseUrl(): string {
+    const resolved =
+        typeof window !== 'undefined'
+            ? window.location.origin
+            : process.env.SITE_URL ||
+              process.env.NEXT_PUBLIC_APP_BASE_URL ||
+              (process.env.VERCEL_PROJECT_PRODUCTION_URL
+                  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+                  : null) ||
+              'https://hultman.dev';
+
+    return stripTrailingSlashes(resolved);
+}
+
+function stripTrailingSlashes(url: string): string {
+    return url.replace(/\/+$/, '');
+}


### PR DESCRIPTION
## Problem

On blog post pages, the canonical, `og:url`, and both JSON-LD URL fields render with a **double slash**:

```
https://hultman.dev//blog/3804d7b8-9add-80b2-88bd-e3a060aefad5
                    ^^
```

Affected fields (4): `<link rel="canonical">`, `og:url`, JSON-LD `url`, and JSON-LD `mainEntityOfPage.@id`. A self-referencing canonical that doesn't match the real URL can muddy indexing and dedupe signals.

**Root cause:** the base URL comes from the `SITE_URL` / `NEXT_PUBLIC_APP_BASE_URL` env var, which is set with a trailing slash. `${baseUrl}/blog/${id}` then yields `//`. This pattern was duplicated across **four** files, all vulnerable:

- `next-seo.config.ts` — homepage canonical / og:url / og image
- `pages/feed.xml.tsx` — RSS `<link>`, `<guid>`, atom self-link
- `pages/sitemap.xml.tsx` — every `<loc>` (e.g. `//about`, `//blog/<id>`)
- `pages/blog/[id].tsx` — the reported page

## Fix

Extract a single `getBaseUrl()` helper (`src/utils/baseUrl.ts`) that resolves the origin and strips trailing slashes, then route all four sites through it. Fixing the join once resolves every affected URL and prevents the same bug recurring elsewhere.

```ts
export function getBaseUrl(): string {
    const resolved =
        typeof window !== 'undefined'
            ? window.location.origin
            : process.env.SITE_URL ||
              process.env.NEXT_PUBLIC_APP_BASE_URL ||
              (process.env.VERCEL_PROJECT_PRODUCTION_URL
                  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
                  : null) ||
              'https://hultman.dev';
    return resolved.replace(/\/+$/, '');
}
```

This also unifies the resolution order (the homepage/feed/sitemap previously lacked the `VERCEL_PROJECT_PRODUCTION_URL` fallback that the blog page had).

> Note: setting the `SITE_URL` env var without the trailing slash would also fix the symptom, but normalizing in code makes the join robust regardless of how the env is configured.

## Test plan

- [ ] After deploy, view source on a blog post and confirm canonical / `og:url` / JSON-LD `url` + `mainEntityOfPage.@id` have a single slash
- [ ] Confirm `/sitemap.xml` `<loc>` entries (homepage, `/about`, `/blog/<id>`) have no `//`
- [ ] Confirm `/feed.xml` `<link>` / `<guid>` entries have no `//`
- [ ] Confirm homepage canonical is still correct