### PR TITLE
Pre-launch hardening: blog/home robustness, a11y, SEO, security

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -69,6 +69,18 @@ module.exports = withBundleAnalyzer({
                 hostname: 's3.us-west-2.amazonaws.com',
                 pathname: '/secure.notion-static.com/**',
             },
+            // Newer Notion workspaces serve uploaded files from this host —
+            // missing it 400s uploaded covers the same way app.notion.com did.
+            {
+                protocol: 'https',
+                hostname: 'prod-files-secure.s3.us-east-1.amazonaws.com',
+                pathname: '/**',
+            },
+            {
+                protocol: 'https',
+                hostname: 's3.us-east-1.amazonaws.com',
+                pathname: '/secure.notion-static.com/**',
+            },
             {
                 protocol: 'https',
                 hostname: 'secure.notion-static.com',
@@ -99,7 +111,10 @@ module.exports = withBundleAnalyzer({
                 headers: [
                     { key: 'X-Content-Type-Options', value: 'nosniff' },
                     { key: 'X-Frame-Options', value: 'DENY' },
-                    { key: 'X-XSS-Protection', value: '1; mode=block' },
+                    {
+                        key: 'Strict-Transport-Security',
+                        value: 'max-age=63072000; includeSubDomains; preload',
+                    },
                     {
                         key: 'Referrer-Policy',
                         value: 'strict-origin-when-cross-origin',

--- a/src/components/Blog/FeaturedPost.tsx
+++ b/src/components/Blog/FeaturedPost.tsx
@@ -14,6 +14,7 @@ import NextImage from 'next/image';
 import NextLink from 'next/link';
 import posthog from 'posthog-js';
 import { BlogPost } from '../../types/notion';
+import { formatNotionDate } from '../../utils/date';
 
 interface FeaturedPostProps {
     post: BlogPost;
@@ -24,6 +25,7 @@ export default function FeaturedPost({ post }: FeaturedPostProps) {
     const border = useColorModeValue('gray.200', 'gray.700');
     const dateColor = useColorModeValue('gray.600', 'gray.400');
     const descColor = useColorModeValue('gray.700', 'gray.300');
+    const titleHover = useColorModeValue('green.700', 'green.400');
 
     const handlePostClick = () => {
         posthog.capture('blog_post_clicked', {
@@ -48,7 +50,7 @@ export default function FeaturedPost({ post }: FeaturedPostProps) {
                 boxShadow: '0 0 0 1px var(--chakra-colors-green-500)',
                 transform: 'translateY(-3px)',
                 '.featured-title-link': {
-                    color: 'green.500',
+                    color: titleHover,
                 },
             }}
         >
@@ -63,7 +65,7 @@ export default function FeaturedPost({ post }: FeaturedPostProps) {
                     >
                         <NextImage
                             src={post.cover}
-                            alt={post.title}
+                            alt=""
                             fill
                             style={{ objectFit: 'cover' }}
                             placeholder="empty"
@@ -130,14 +132,7 @@ export default function FeaturedPost({ post }: FeaturedPostProps) {
 
                     <Text color={dateColor} fontSize="xs">
                         {post.publishedDate
-                            ? new Date(post.publishedDate).toLocaleDateString(
-                                  'en-US',
-                                  {
-                                      year: 'numeric',
-                                      month: 'short',
-                                      day: 'numeric',
-                                  }
-                              )
+                            ? formatNotionDate(post.publishedDate)
                             : 'Unpublished'}
                         {post.readingTime != null &&
                             ` · ${post.readingTime} min read`}

--- a/src/components/Blog/PostBox.tsx
+++ b/src/components/Blog/PostBox.tsx
@@ -13,6 +13,7 @@ import NextImage from 'next/image';
 import NextLink from 'next/link';
 import posthog from 'posthog-js';
 import { BlogPost } from '../../types/notion';
+import { formatNotionDate } from '../../utils/date';
 
 interface PostBoxProps {
     post: BlogPost;
@@ -23,6 +24,7 @@ export default function PostBox({ post }: PostBoxProps) {
     const border = useColorModeValue('gray.200', 'gray.700');
     const dateColor = useColorModeValue('gray.600', 'gray.400');
     const descColor = useColorModeValue('gray.700', 'gray.300');
+    const titleHover = useColorModeValue('green.700', 'green.400');
 
     const handlePostClick = () => {
         posthog.capture('blog_post_clicked', {
@@ -49,7 +51,7 @@ export default function PostBox({ post }: PostBoxProps) {
                 boxShadow: '0 0 0 1px var(--chakra-colors-green-500)',
                 transform: 'translateY(-3px)',
                 '.post-title-link': {
-                    color: 'green.500',
+                    color: titleHover,
                 },
             }}
         >
@@ -62,7 +64,7 @@ export default function PostBox({ post }: PostBoxProps) {
                 >
                     <NextImage
                         src={post.cover}
-                        alt={post.title}
+                        alt=""
                         fill
                         style={{ objectFit: 'cover' }}
                         placeholder="empty"
@@ -111,14 +113,7 @@ export default function PostBox({ post }: PostBoxProps) {
 
                 <Text color={dateColor} fontSize="xs" mt="auto">
                     {post.publishedDate
-                        ? new Date(post.publishedDate).toLocaleDateString(
-                              'en-US',
-                              {
-                                  year: 'numeric',
-                                  month: 'short',
-                                  day: 'numeric',
-                              }
-                          )
+                        ? formatNotionDate(post.publishedDate)
                         : 'Unpublished'}
                     {post.readingTime != null &&
                         ` · ${post.readingTime} min read`}

--- a/src/components/BlogPostingJsonLd.tsx
+++ b/src/components/BlogPostingJsonLd.tsx
@@ -25,17 +25,25 @@ export default function BlogPostingJsonLd({
         ...(datePublished && { datePublished }),
         ...(dateModified && { dateModified }),
         ...(description && { description }),
-        ...(image && { image }),
+        // Google prefers an array for the image field.
+        ...(image && { image: [image] }),
         url,
         author: {
             '@type': 'Person',
             name: 'Adam Hultman',
             url: 'https://hultman.dev',
         },
+        // Rich Results expects an Organization publisher with a logo.
         publisher: {
-            '@type': 'Person',
+            '@type': 'Organization',
             name: 'Adam Hultman',
             url: 'https://hultman.dev',
+            logo: {
+                '@type': 'ImageObject',
+                url: 'https://hultman.dev/android-chrome-512x512.png',
+                width: 512,
+                height: 512,
+            },
         },
         mainEntityOfPage: {
             '@type': 'WebPage',
@@ -48,7 +56,9 @@ export default function BlogPostingJsonLd({
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
-                    __html: JSON.stringify(schema),
+                    // Escape "<" so a "</script>" in any Notion-sourced field
+                    // can't break out of the script tag.
+                    __html: JSON.stringify(schema).replace(/</g, '\\u003c'),
                 }}
                 key="blogposting-jsonld"
             />

--- a/src/components/Chat/InputArea.tsx
+++ b/src/components/Chat/InputArea.tsx
@@ -88,8 +88,9 @@ const InputArea = memo(function InputArea({
                     }
                     aria-label="Message input"
                     bg={msgInputColor}
-                    _focus={{
-                        outline: 'none',
+                    _focusVisible={{
+                        borderColor: 'green.500',
+                        boxShadow: '0 0 0 1px var(--chakra-colors-green-500)',
                     }}
                     value={input}
                     onChange={onInputChange}

--- a/src/components/Home/Hero.tsx
+++ b/src/components/Home/Hero.tsx
@@ -1,5 +1,12 @@
-import { Badge, Box, Button, Flex, Heading } from '@chakra-ui/react';
-import { AnimatePresence, motion } from 'framer-motion';
+import {
+    Badge,
+    Box,
+    Button,
+    Flex,
+    Heading,
+    useColorModeValue,
+} from '@chakra-ui/react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { useEffect, useState } from 'react';
 import NextImage from 'next/image';
 
@@ -15,14 +22,21 @@ const SUBTITLES = [
 ];
 
 function TypedSubtitle() {
+    const prefersReducedMotion = useReducedMotion();
+    const subtitleColor = useColorModeValue('green.700', 'green.400');
     const [index, setIndex] = useState(0);
 
     useEffect(() => {
+        // Don't auto-rotate for users who prefer reduced motion — an
+        // indefinitely moving text element is a WCAG 2.2.2 concern.
+        if (prefersReducedMotion) {
+            return;
+        }
         const timer = setInterval(() => {
             setIndex((i) => (i + 1) % SUBTITLES.length);
         }, 2500);
         return () => clearInterval(timer);
-    }, []);
+    }, [prefersReducedMotion]);
 
     return (
         <Box
@@ -42,7 +56,7 @@ function TypedSubtitle() {
                     <Paragraph
                         fontSize={{ base: 'lg', md: '2xl' }}
                         lineHeight={1.5}
-                        color="green.500"
+                        color={subtitleColor}
                         fontWeight="medium"
                         m={0}
                     >
@@ -119,28 +133,28 @@ function Hero() {
                 </Box>
             </Flex>
             <Flex gap={3} mt={6} wrap="wrap">
-                <Link href="#contact">
-                    <Button
-                        colorScheme="green"
-                        size={{ base: 'md', md: 'lg' }}
-                        bg="green.600"
-                        _hover={{ bg: 'green.700' }}
-                        color="white"
-                        leftIcon={<FaEnvelope />}
-                    >
-                        Say hello
-                    </Button>
-                </Link>
-                <Link href="/about">
-                    <Button
-                        size={{ base: 'md', md: 'lg' }}
-                        variant="outline"
-                        colorScheme="green"
-                        leftIcon={<FaUser />}
-                    >
-                        Read my story
-                    </Button>
-                </Link>
+                <Button
+                    as={Link}
+                    href="#contact"
+                    colorScheme="green"
+                    size={{ base: 'md', md: 'lg' }}
+                    bg="green.600"
+                    _hover={{ bg: 'green.700' }}
+                    color="white"
+                    leftIcon={<FaEnvelope />}
+                >
+                    Say hello
+                </Button>
+                <Button
+                    as={Link}
+                    href="/about"
+                    size={{ base: 'md', md: 'lg' }}
+                    variant="outline"
+                    colorScheme="green"
+                    leftIcon={<FaUser />}
+                >
+                    Read my story
+                </Button>
             </Flex>
         </motion.div>
     );

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -46,38 +46,32 @@ function Home() {
             <ChatIntro />
             <Chat />
             <Flex justify="center" w="100%" py={2}>
-                <Link href="#contact">
-                    <Button
-                        variant="ghost"
-                        colorScheme="green"
-                        rightIcon={<FaArrowRight />}
-                        size="sm"
-                    >
-                        Want to talk to the real Adam?
-                    </Button>
-                </Link>
+                <Button
+                    as={Link}
+                    href="#contact"
+                    variant="ghost"
+                    colorScheme="green"
+                    rightIcon={<FaArrowRight />}
+                    size="sm"
+                >
+                    Want to talk to the real Adam?
+                </Button>
             </Flex>
             <FeaturedWork />
-            <Flex
-                direction="column"
-                align="center"
-                w="100%"
-                py={2}
-                gap={1}
-            >
+            <Flex direction="column" align="center" w="100%" py={2} gap={1}>
                 <Text fontSize="sm" color="gray.600">
                     Interested in working together?
                 </Text>
-                <Link href="#contact">
-                    <Button
-                        variant="outline"
-                        colorScheme="green"
-                        rightIcon={<FaArrowRight />}
-                        size="sm"
-                    >
-                        Get in touch
-                    </Button>
-                </Link>
+                <Button
+                    as={Link}
+                    href="#contact"
+                    variant="outline"
+                    colorScheme="green"
+                    rightIcon={<FaArrowRight />}
+                    size="sm"
+                >
+                    Get in touch
+                </Button>
             </Flex>
             <Flex justifyContent="center">
                 <GitTimeline />

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Flex } from '@chakra-ui/react';
+import { Container, Flex, Link } from '@chakra-ui/react';
 import { Roboto_Mono } from 'next/font/google';
 import { PropsWithChildren } from 'react';
 import Footer from './Footer';
@@ -12,9 +12,32 @@ const robotoMono = Roboto_Mono({
 function Layout({ children }: PropsWithChildren) {
     return (
         <Container maxW="container.xl" className={robotoMono.className} px={0}>
+            <Link
+                href="#main"
+                position="absolute"
+                left="-9999px"
+                _focus={{
+                    left: '50%',
+                    top: '8px',
+                    transform: 'translateX(-50%)',
+                    zIndex: 'skipLink',
+                    px: 4,
+                    py: 2,
+                    bg: 'green.600',
+                    color: 'white',
+                    borderRadius: 'md',
+                }}
+            >
+                Skip to content
+            </Link>
             <Flex alignItems="center" flexDirection="column">
                 <Navbar />
-                <Container as="main" maxW="container.xl" mt={{ base: '80px', md: '106px' }}>
+                <Container
+                    as="main"
+                    id="main"
+                    maxW="container.xl"
+                    mt={{ base: '80px', md: '106px' }}
+                >
                     {children}
                 </Container>
                 <Footer />

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -9,19 +9,21 @@ interface Props {
 function Message({ message = 'Such an empty place!', type = 'empty' }: Props) {
     const Icon = type === 'empty' ? FaClock : FaInfo;
     const borderColor = useColorModeValue('gray.100', 'gray.700');
+    const textColor = useColorModeValue('gray.600', 'gray.400');
 
     return (
         <Box
             mt={10}
             display="flex"
             alignItems="center"
+            color={textColor}
             borderColor={borderColor}
             borderWidth="1px"
             p={4}
             borderRadius="lg"
         >
-            <Icon style={{ color: '#718096' }} />
-            <Text color="gray.500" fontSize="lg" ml={2}>
+            <Icon style={{ color: 'currentcolor' }} />
+            <Text color={textColor} fontSize="lg" ml={2}>
                 {message}
             </Text>
         </Box>

--- a/src/components/RenderBlocks/BlockBookmark.tsx
+++ b/src/components/RenderBlocks/BlockBookmark.tsx
@@ -1,19 +1,20 @@
 import { WithContentValidationProps } from '@9gustin/react-notion-render/dist/hoc/withContentValidation';
-import { Box, Link } from '@chakra-ui/react';
+import { Box, Link, useColorModeValue } from '@chakra-ui/react';
 
 function BlockBookmark({ block }: WithContentValidationProps) {
+    const linkColor = useColorModeValue('green.700', 'green.400');
+
     if (!block.content?.url) {
         return null;
     }
 
     const caption =
-        block.content.caption
-            ?.map((text) => text.plain_text || '')
-            .join('') || block.content.url;
+        block.content.caption?.map((text) => text.plain_text || '').join('') ||
+        block.content.url;
 
     return (
         <Box mb="1.5rem">
-            <Link href={block.content.url} isExternal color="green.500">
+            <Link href={block.content.url} isExternal color={linkColor}>
                 {caption}
             </Link>
         </Box>

--- a/src/components/RenderBlocks/BlockImage.tsx
+++ b/src/components/RenderBlocks/BlockImage.tsx
@@ -2,14 +2,20 @@ import { WithContentValidationProps } from '@9gustin/react-notion-render/dist/ho
 import { Image } from '@chakra-ui/react';
 
 function BlockImage({ block }: WithContentValidationProps) {
-    if (!block.content) {
+    const src = block.content?.external?.url || block.content?.file?.url;
+
+    // Guard against a malformed/deleted image block rendering a broken <img>.
+    if (!src) {
         return null;
     }
 
     return (
         <Image
-            src={block.content.external?.url || block.content.file?.url || ''}
-            alt={block.content.caption?.[0]?.plain_text || ''}
+            src={src}
+            alt={block.content?.caption?.[0]?.plain_text || ''}
+            loading="lazy"
+            borderRadius="md"
+            my={4}
         />
     );
 }

--- a/src/main.css
+++ b/src/main.css
@@ -149,3 +149,17 @@ a:hover {
 .divider + .section-loading {
     display: none !important;
 }
+
+/* Respect users who prefer reduced motion — neutralize CSS animations and
+   transitions (e.g. the infinitely spinning logo). JS-driven animations are
+   gated separately via framer-motion's useReducedMotion. */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import { ipAddress } from '@vercel/functions';
 import { Ratelimit } from '@upstash/ratelimit';
 import { kv } from '@vercel/kv';
 
-// Rate limit: 5 requests per 10 seconds per IP
+// General rate limit for read-only API routes: 5 requests per 10 seconds per IP
 const ratelimit = new Ratelimit({
     redis: kv,
     limiter: Ratelimit.slidingWindow(5, '10 s'),
@@ -11,11 +11,21 @@ const ratelimit = new Ratelimit({
     prefix: '@upstash/ratelimit',
 });
 
+// Tighter limit for the chat endpoint — the only route with real (OpenAI)
+// cost, and the one worth protecting most aggressively from abuse.
+const chatRatelimit = new Ratelimit({
+    redis: kv,
+    limiter: Ratelimit.slidingWindow(5, '60 s'),
+    analytics: true,
+    prefix: '@upstash/ratelimit:chat',
+});
+
 export const config = {
     matcher: '/api/:path*',
 };
 
 const LOCAL_IP = '127.0.0.1';
+const CHAT_PATH = '/api/v1/chat';
 
 /**
  * Middleware to apply rate limiting to API routes
@@ -29,9 +39,11 @@ export default async function middleware(request: NextRequest) {
         return NextResponse.next();
     }
 
+    const isChat = request.nextUrl.pathname.startsWith(CHAT_PATH);
+    const limiter = isChat ? chatRatelimit : ratelimit;
+
     try {
-        const { success, limit, remaining, reset } =
-            await ratelimit.limit(ip);
+        const { success, limit, remaining, reset } = await limiter.limit(ip);
 
         const response = success
             ? NextResponse.next()
@@ -51,7 +63,18 @@ export default async function middleware(request: NextRequest) {
         return response;
     } catch (error) {
         console.error('Rate limiting error:', error);
-        // Allow request to proceed if rate limiting fails
+        // Fail closed for the billable chat endpoint so an Upstash outage
+        // can't open an unmetered window on the OpenAI key; fail open for the
+        // read-only Notion routes where availability matters more.
+        if (isChat) {
+            return NextResponse.json(
+                {
+                    error: 'Service unavailable',
+                    message: 'Please try again later',
+                },
+                { status: 503 }
+            );
+        }
         return NextResponse.next();
     }
 }

--- a/src/pages/api/v1/chat.ts
+++ b/src/pages/api/v1/chat.ts
@@ -20,8 +20,50 @@ const systemInitMessage = serverConfig.OPENAI_SYSTEM_INIT_MSG.replace(
     CURR_DATE
 );
 
+const MAX_MESSAGES = 20;
+const MAX_MESSAGE_LENGTH = 1000;
+
+function isValidMessage(
+    message: unknown
+): message is { role: 'user' | 'assistant'; content: string } {
+    if (typeof message !== 'object' || message === null) {
+        return false;
+    }
+    const record = message as Record<string, unknown>;
+    return (
+        (record.role === 'user' || record.role === 'assistant') &&
+        typeof record.content === 'string' &&
+        record.content.length > 0 &&
+        record.content.length <= MAX_MESSAGE_LENGTH
+    );
+}
+
 export default async function handler(req: NextRequest) {
-    const { messages } = await req.json();
+    // The client maxLength is cosmetic — validate server-side to keep this
+    // public, billable endpoint from being abused to drain the OpenAI key.
+    if (req.method !== 'POST') {
+        return new Response('Method Not Allowed', {
+            status: 405,
+            headers: { Allow: 'POST' },
+        });
+    }
+
+    let body: unknown;
+    try {
+        body = await req.json();
+    } catch {
+        return new Response('Invalid JSON body', { status: 400 });
+    }
+
+    const messages = (body as { messages?: unknown })?.messages;
+    if (
+        !Array.isArray(messages) ||
+        messages.length === 0 ||
+        messages.length > MAX_MESSAGES ||
+        !messages.every(isValidMessage)
+    ) {
+        return new Response('Invalid request', { status: 400 });
+    }
 
     const userAgent = req.headers.get('user-agent');
     const isMobile = /mobile/i.test(userAgent || '');

--- a/src/pages/api/v1/contact.ts
+++ b/src/pages/api/v1/contact.ts
@@ -7,6 +7,16 @@ type Data = {
     message: string;
 };
 
+// Cap the request body so oversized payloads are rejected before the
+// field-level length checks ever parse them into memory.
+export const config = {
+    api: {
+        bodyParser: {
+            sizeLimit: '16kb',
+        },
+    },
+};
+
 /**
  * Sanitizes user input to prevent XSS attacks by escaping HTML special characters
  */

--- a/src/pages/api/v1/post/[id].ts
+++ b/src/pages/api/v1/post/[id].ts
@@ -6,6 +6,11 @@ import { pageIsPageObjectResponse } from '../../../../utils/notion';
 
 const notion = new Client({ auth: serverConfig.NOTION_API_KEY });
 
+// Notion page IDs are UUIDs (with or without hyphens). Validate before
+// forwarding to the Notion SDK so arbitrary input doesn't reach it.
+const NOTION_ID_PATTERN =
+    /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
+
 export default async function handler(
     req: NextApiRequest,
     res: NextApiResponse
@@ -17,7 +22,7 @@ export default async function handler(
         return res.status(405).json({ message: 'Method not allowed' });
     }
 
-    if (typeof id !== 'string') {
+    if (typeof id !== 'string' || !NOTION_ID_PATTERN.test(id)) {
         return res.status(400).json({ message: 'Invalid request' });
     }
 

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -10,13 +10,14 @@ import {
     Container,
     Divider,
     Heading,
-    Link,
     Stack,
     Tag,
     Text,
     VStack,
+    useColorModeValue,
 } from '@chakra-ui/react';
 import NextImage from 'next/image';
+import NextLink from 'next/link';
 import { ArrowLeftIcon } from '@chakra-ui/icons';
 import { NotionBlock as RNRNotionBlock } from '@9gustin/react-notion-render';
 import { useEffect } from 'react';
@@ -27,6 +28,7 @@ import { fetchNotion, fetchNotions } from '../../services/notion';
 import { NotionPageWithBlocks } from '../../types/notion';
 import { estimateReadingTime } from '../../utils/readingTime';
 import { getBaseUrl } from '../../utils/baseUrl';
+import { formatNotionDate } from '../../utils/date';
 
 const roboto = Roboto({
     subsets: ['latin'],
@@ -51,6 +53,8 @@ interface Props {
 }
 
 function BlogPost({ post, seo, jsonLd, readingTime }: Props) {
+    const metaColor = useColorModeValue('gray.600', 'gray.400');
+
     useEffect(() => {
         if (typeof window !== 'undefined') {
             const updateScrollProgress = () => {
@@ -87,11 +91,13 @@ function BlogPost({ post, seo, jsonLd, readingTime }: Props) {
                                 Sorry, this post could not be found. Please try
                                 again later.
                             </Alert>
-                            <Link href="/blog">
-                                <Button leftIcon={<ArrowLeftIcon />}>
-                                    Back to blog
-                                </Button>
-                            </Link>
+                            <Button
+                                as={NextLink}
+                                href="/blog"
+                                leftIcon={<ArrowLeftIcon />}
+                            >
+                                Back to blog
+                            </Button>
                         </VStack>
                     </Center>
                 </Container>
@@ -123,22 +129,19 @@ function BlogPost({ post, seo, jsonLd, readingTime }: Props) {
                 <Text
                     as="time"
                     dateTime={page.publishedDate || undefined}
-                    color="gray.500"
+                    color={metaColor}
                     mb={2}
                     display="block"
                 >
                     {page.publishedDate
-                        ? new Date(page.publishedDate).toLocaleDateString(
-                              'en-US',
-                              {
-                                  year: 'numeric',
-                                  month: 'long',
-                                  day: 'numeric',
-                              }
-                          )
+                        ? formatNotionDate(page.publishedDate, {
+                              year: 'numeric',
+                              month: 'long',
+                              day: 'numeric',
+                          })
                         : 'Unpublished'}
                 </Text>
-                <Text color="gray.500" mb={4}>
+                <Text color={metaColor} mb={4}>
                     By Adam Hultman · {readingTime} min read
                 </Text>
                 {page.tags && page.tags.length > 0 && (
@@ -174,11 +177,13 @@ function BlogPost({ post, seo, jsonLd, readingTime }: Props) {
                 <RenderBlocks blocks={blocks.results as RNRNotionBlock[]} />
 
                 <Box mt={8} textAlign="center">
-                    <Link href="/blog">
-                        <Button leftIcon={<ArrowLeftIcon />}>
-                            Back to Blog List
-                        </Button>
-                    </Link>
+                    <Button
+                        as={NextLink}
+                        href="/blog"
+                        leftIcon={<ArrowLeftIcon />}
+                    >
+                        Back to Blog List
+                    </Button>
                 </Box>
             </Box>
         </>
@@ -201,26 +206,42 @@ export async function getStaticProps({
 
         const { page } = post;
 
-        let ogImageUrl = `${baseUrl}/og_blog_fallback.png`;
+        // Notion uploads are short-lived signed S3 URLs; using one as the OG /
+        // JSON-LD image means social cards 404 once the signature expires.
+        // Only durable covers (external gallery, Unsplash) are safe to share —
+        // otherwise fall back to the static image.
+        const fallbackOgImage = `${baseUrl}/og_blog_fallback.png`;
+        const isExpiringUrl = (url: string) => url.includes('amazonaws.com');
+        const ogImageUrl =
+            page.cover && !isExpiringUrl(page.cover)
+                ? page.cover
+                : fallbackOgImage;
 
-        if (page.cover) {
-            ogImageUrl = page.cover;
-        }
+        // Omit empty descriptions entirely rather than emitting empty meta /
+        // og:description tags (worse for SEO than no tag).
+        const description = page.description || undefined;
+
+        // dateModified must be >= datePublished or Rich Results rejects the
+        // schema; clamp in case a post is given a future Published date.
+        const dateModified =
+            page.publishedDate && page.last_edited_time < page.publishedDate
+                ? page.publishedDate
+                : page.last_edited_time;
 
         const postUrl = `${baseUrl}/blog/${page.id}`;
 
         const seoProps: NextSeoProps = {
             title: page.title,
-            description: page.description,
+            description,
             canonical: postUrl,
             openGraph: {
                 title: page.title,
-                description: page.description,
+                description,
                 url: postUrl,
                 type: 'article',
                 article: {
                     publishedTime: page.publishedDate || undefined,
-                    modifiedTime: page.last_edited_time,
+                    modifiedTime: dateModified,
                     authors: ['Adam Hultman'],
                     tags: page.tags,
                 },
@@ -238,8 +259,8 @@ export async function getStaticProps({
         const jsonLd: BlogPostingJsonLdData = {
             headline: page.title,
             datePublished: page.publishedDate || undefined,
-            dateModified: page.last_edited_time,
-            description: page.description,
+            dateModified,
+            description,
             image: ogImageUrl,
             url: postUrl,
         };
@@ -263,7 +284,9 @@ export async function getStaticProps({
 
 export async function getStaticPaths() {
     try {
-        const posts = await fetchNotions('blog');
+        // Prebuild all posts (default page_size is only 10), so older posts
+        // are served statically instead of cold-rendering on first visit.
+        const posts = await fetchNotions('blog', { page_size: 100 });
         const paths = posts.map((post) => ({
             params: { id: post.id },
         }));

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,5 +1,4 @@
 import {
-    Box,
     Container,
     Heading,
     SimpleGrid,
@@ -45,6 +44,14 @@ function BlogPage({ posts }: Props) {
                     title: 'Blog | Adam Hultman',
                     description:
                         'Notes on engineering, AI, security, and building things that last.',
+                    images: [
+                        {
+                            url: 'https://hultman.dev/og_homepage.png',
+                            width: 1200,
+                            height: 630,
+                            alt: 'Adam Hultman — Blog',
+                        },
+                    ],
                 }}
             />
             <Container maxW="container.lg">
@@ -130,9 +137,11 @@ export async function getStaticProps() {
             props: {
                 posts,
             },
-            revalidate: 43200, // 12 hours
+            // Match the post page so Notion signed cover URLs (~1h TTL) and
+            // newly published posts don't stay stale for half a day.
+            revalidate: 3600, // 1 hour
         };
-    } catch (error) {
+    } catch {
         return {
             props: {
                 posts: [],

--- a/src/pages/feed.xml.tsx
+++ b/src/pages/feed.xml.tsx
@@ -18,7 +18,27 @@ function Feed() {
     return null;
 }
 
+function buildFeedXml(itemsXml: string): string {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Adam Hultman — Blog</title>
+    <link>${SITE_URL}/blog</link>
+    <description>Notes on engineering, AI, security, and building things that last.</description>
+    <language>en-us</language>
+    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml" />
+${itemsXml}
+  </channel>
+</rss>`;
+}
+
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+    res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8');
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=43200, stale-while-revalidate=86400'
+    );
+
     try {
         const posts: BlogPost[] = await fetchNotions('blog', {
             page_size: 100,
@@ -38,31 +58,15 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     </item>`;
         });
 
-        const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>Adam Hultman — Blog</title>
-    <link>${SITE_URL}/blog</link>
-    <description>Notes on engineering, AI, security, and building things that last.</description>
-    <language>en-us</language>
-    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml" />
-${items.join('\n')}
-  </channel>
-</rss>`;
-
-        res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8');
-        res.setHeader(
-            'Cache-Control',
-            'public, s-maxage=43200, stale-while-revalidate=86400'
-        );
-        res.write(xml);
-        res.end();
-
-        return { props: {} };
+        res.write(buildFeedXml(items.join('\n')));
     } catch (error) {
         console.error('Error generating RSS feed:', error);
-        return { props: {} };
+        // Emit a valid, item-less feed rather than a blank body on failure.
+        res.write(buildFeedXml(''));
     }
+
+    res.end();
+    return { props: {} };
 };
 
 export default Feed;

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -10,58 +10,73 @@ function Sitemap() {
     return null;
 }
 
+const STATIC_PATHS = [
+    '',
+    '/about',
+    '/bookmarks',
+    '/books',
+    '/blog',
+    '/labs',
+    '/labs/interaction-checker',
+    '/labs/token-viz',
+    '/labs/prompt-duel',
+    '/labs/agent-flow',
+    '/labs/evidence-viz',
+    '/labs/beatmaker',
+];
+
+interface SitemapUrl {
+    loc: string;
+    lastmod: string;
+}
+
+function buildSitemapXml(urls: SitemapUrl[]): string {
+    return (
+        `<?xml version="1.0" encoding="UTF-8"?>\n` +
+        `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+        urls
+            .map(
+                ({ loc, lastmod }) =>
+                    `<url><loc>${loc}</loc><lastmod>${lastmod}</lastmod></url>`
+            )
+            .join('\n') +
+        `\n</urlset>`
+    );
+}
+
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+    const today = new Date().toISOString().slice(0, 10);
+    const staticUrls: SitemapUrl[] = STATIC_PATHS.map((path) => ({
+        loc: `${SITE_URL}${path}`,
+        lastmod: today,
+    }));
+
+    res.setHeader('Content-Type', 'text/xml');
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=43200, stale-while-revalidate=86400'
+    );
+
     try {
-        const staticPaths = [
-            '',
-            '/about',
-            '/bookmarks',
-            '/books',
-            '/blog',
-            '/labs',
-            '/labs/interaction-checker',
-            '/labs/token-viz',
-            '/labs/prompt-duel',
-            '/labs/agent-flow',
-            '/labs/evidence-viz',
-            '/labs/beatmaker',
-        ];
         const posts: BlogPost[] = await fetchNotions('blog', {
             page_size: 100,
         });
 
-        const urls = staticPaths.map((path) => ({
-            loc: `${SITE_URL}${path}`,
-            lastmod: new Date().toISOString().split('T')[0],
-        }));
-
-        const postUrls = posts.map((post) => ({
+        const postUrls: SitemapUrl[] = posts.map((post) => ({
             loc: `${SITE_URL}/blog/${post.id}`,
-            lastmod: post.last_edited_time.split('T')[0],
+            lastmod: post.last_edited_time.slice(0, 10),
         }));
 
-        const allUrls = [...urls, ...postUrls];
-
-        const xml =
-            `<?xml version="1.0" encoding="UTF-8"?>\n` +
-            `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-            allUrls
-                .map(
-                    ({ loc, lastmod }) =>
-                        `<url><loc>${loc}</loc><lastmod>${lastmod}</lastmod></url>`
-                )
-                .join('\n') +
-            `\n</urlset>`;
-
-        res.setHeader('Content-Type', 'text/xml');
-        res.write(xml);
-        res.end();
-
-        return { props: {} };
+        res.write(buildSitemapXml([...staticUrls, ...postUrls]));
     } catch (error) {
         console.error('Error generating sitemap:', error);
-        return { props: {} };
+        // Still emit a valid sitemap of static paths so a transient Notion
+        // outage doesn't drop every URL from a crawl.
+        res.write(buildSitemapXml(staticUrls));
     }
+
+    res.end();
+    return { props: {} };
 };
 
 export default Sitemap;

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -2,6 +2,7 @@ import { Client } from '@notionhq/client';
 import type {
     PageObjectResponse,
     QueryDatabaseParameters,
+    ListBlockChildrenResponse,
 } from '@notionhq/client/build/src/api-endpoints';
 import { serverConfig } from '../config';
 import {
@@ -140,16 +141,43 @@ export async function fetchNotions<T extends DatabaseName>(
 }
 
 /**
- * Estimate a single blog post's reading time by fetching its top-level
- * blocks. Falls back to 1 minute if the block fetch fails so the listing
- * never breaks on a transient Notion error.
+ * List a page's top-level child blocks, following pagination.
+ *
+ * Notion returns at most 100 blocks per call; long posts would otherwise be
+ * silently truncated in both rendering and reading-time estimation. Bounded by
+ * `maxPages` to keep on-demand renders fast. Nested children (toggles, columns)
+ * are still not recursed — that would require a call per parent block.
+ */
+async function listAllBlockChildren(
+    blockId: string,
+    maxPages = 5
+): Promise<ListBlockChildrenResponse> {
+    const first = await notion.blocks.children.list({ block_id: blockId });
+    const results = [...first.results];
+
+    let cursor = first.next_cursor;
+    let page = 1;
+    while (cursor && page < maxPages) {
+        const next = await notion.blocks.children.list({
+            block_id: blockId,
+            start_cursor: cursor,
+        });
+        results.push(...next.results);
+        cursor = next.next_cursor;
+        page++;
+    }
+
+    return { ...first, results, has_more: false, next_cursor: null };
+}
+
+/**
+ * Estimate a single blog post's reading time from its content. Falls back to
+ * 1 minute if the block fetch fails so the listing never breaks on a transient
+ * Notion error.
  */
 async function fetchBlogPostReadingTime(id: string): Promise<number> {
     try {
-        const blockChildrenResponse = await notion.blocks.children.list({
-            block_id: id,
-        });
-        const blocks = blockChildrenResponse.results.filter(
+        const blocks = (await listAllBlockChildren(id)).results.filter(
             isBlockObjectResponse
         );
         return estimateReadingTime(blocks);
@@ -202,9 +230,7 @@ export async function fetchNotion<T extends DatabaseName>(db: T, id: string) {
             return null;
         }
 
-        const blockChildrenResponse = await notion.blocks.children.list({
-            block_id: id,
-        });
+        const blockChildrenResponse = await listAllBlockChildren(id);
         const filteredBlocks = blockChildrenResponse.results.filter(
             isBlockObjectResponse
         );

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,30 @@
+/**
+ * Parse a Notion date string into a Date in the viewer's local timezone.
+ *
+ * Notion date-only values ("2025-06-10") are parsed by the JS engine as UTC
+ * midnight, so `toLocaleDateString()` renders them as the *previous* day for
+ * any viewer west of UTC (all of the Americas). Appending a local-time
+ * component forces local parsing so the displayed day matches what was
+ * published. Datetime values (with a time/zone) are passed through unchanged.
+ */
+export function parseNotionDate(dateStr: string): Date {
+    const isDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(dateStr);
+    return new Date(isDateOnly ? `${dateStr}T00:00:00` : dateStr);
+}
+
+const DEFAULT_OPTIONS: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+};
+
+/**
+ * Format a Notion date string for display, parsed in the viewer's local
+ * timezone (see {@link parseNotionDate}).
+ */
+export function formatNotionDate(
+    dateStr: string,
+    options: Intl.DateTimeFormatOptions = DEFAULT_OPTIONS
+): string {
+    return parseNotionDate(dateStr).toLocaleDateString('en-US', options);
+}

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -21,10 +21,13 @@ export function getTitle(
     page: PageObjectResponse,
     defaultValue: string = 'Untitled'
 ): string {
-    if (page.properties.Name?.type === 'title') {
-        return page.properties.Name.title[0]?.plain_text || defaultValue;
-    }
-    return defaultValue;
+    // Find the title property by type rather than hardcoding the name "Name" —
+    // a renamed title column would otherwise make every post "Untitled".
+    const titleProp = Object.values(page.properties).find(
+        (prop): prop is Extract<typeof prop, { type: 'title' }> =>
+            prop.type === 'title'
+    );
+    return titleProp?.title[0]?.plain_text || defaultValue;
 }
 
 export function getCover(page: PageObjectResponse): string | null {


### PR DESCRIPTION
Implements the actionable findings from the full-site audit, prioritized for important visitors landing on **/blog** and **/**. Five themed commits; `tsc`, `eslint`, and a full `next build` all pass.

## 🔴 Highest-impact (visitor-visible / cost)
- **Uploaded-image hosts allowlisted** — `prod-files-secure.s3.us-east-1` + `s3.us-east-1`, so an uploaded cover from a newer Notion workspace won't 400 like `app.notion.com` did.
- **Durable social cards** — OG/JSON-LD image skips expiring Notion signed S3 URLs (which 404 after ~1h) and falls back to the static image. Listing `revalidate` cut 12h→1h to track the signed-URL TTL.
- **Contrast (WCAG AA + project rule)** — `green.500` title-hover / Hero subtitle and `gray.500` byline replaced with `green.700`/`gray.600` (color-mode aware).
- **`getStaticPaths` prebuilds all posts** (`page_size:100`) so older posts are static, not cold-rendered.
- **Chat endpoint hardened** — POST-only + payload validation (array, count + per-message role/length caps) closes a direct OpenAI cost-abuse vector; dedicated tighter rate-limit window that **fails closed**.

## 🟠 Also fixed
- Published-date **off-by-one west of UTC** (shared `formatNotionDate`; Notion date-only values were parsed as UTC midnight).
- Invalid **`<a><button>` nesting** → `Button as={NextLink}` (Hero/Home CTAs, blog "Back").
- **JSON-LD**: Organization publisher + logo, `image` as array, `</script>` escaped, `dateModified ≥ datePublished` clamp.
- Empty Notion description no longer emits empty `<meta>`/`og:description`.
- `getTitle` finds the title property **by type** (renaming the Notion column no longer breaks every post).
- **Block pagination** (bounded) so long posts aren't truncated in rendering or reading-time.
- **sitemap/feed** emit valid XML on a Notion error instead of a blank body; sitemap gets `Cache-Control`.
- A11y: restored chat-input **focus ring**, **skip-to-content** link, **prefers-reduced-motion** (rotating subtitle + global CSS), decorative card covers `alt=""`.
- Security: **HSTS** header (dropped legacy `X-XSS-Protection`), contact **body-size cap**, Notion-**UUID validation** on `post/[id]`.

## Deliberately deferred (too risky to do blind before visitors)
- **Enforcing a CSP** — needs browser testing against Chakra/Emotion inline styles + PostHog; would risk breaking the site. HSTS added now; CSP should be staged (report-only first).
- **`ai`/`@ai-sdk` major upgrade** for the audit's 1 critical `npm audit` advisory — it's a breaking `ai@6` bump; warrants its own PR + testing.
- **Full image proxy** for in-post Notion images — the 1h revalidate + lazy-load mitigates; a streaming proxy is the complete fix but a bigger change.
- **1.7 MB `og_blog_fallback.png`** — needs a binary re-export (can't do in a code PR); replace with an optimized <200 KB 1200×630.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `next build` succeeds (all pages compile; `/blog` 1h revalidate, `/blog/[id]` SSG)
- [ ] After deploy: blog covers load; dates correct in a US timezone; view-source shows Organization publisher + single-slash URLs; share-unfurl shows an image; chat rejects a malformed `curl`; `prefers-reduced-motion` stops the rotating subtitle
- [ ] `npx pa11y-ci` 5/5 (note: post page `/blog/[id]` still not in `.pa11yci.js` — needs a stable id)